### PR TITLE
Tests for ProtocolTransport

### DIFF
--- a/SwiftLSPClient.xcodeproj/project.pbxproj
+++ b/SwiftLSPClient.xcodeproj/project.pbxproj
@@ -8,8 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		C90F9BB421773CB800EC3854 /* LanguageServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90F9BB321773CB800EC3854 /* LanguageServer.swift */; };
+		C9361B5E220DD9F600254280 /* MockProtocolTransportMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9361B5D220DD9F600254280 /* MockProtocolTransportMessage.swift */; };
 		C96CB61E220C8C2F00F13A36 /* SymbolKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96CB61D220C8C2F00F13A36 /* SymbolKind.swift */; };
 		C96CB620220C917B00F13A36 /* WorkspaceFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96CB61F220C917B00F13A36 /* WorkspaceFolder.swift */; };
+		C96CB62A220D11D700F13A36 /* ProtocolTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96CB629220D11D700F13A36 /* ProtocolTransportTests.swift */; };
+		C96CB62E220D120900F13A36 /* MockDataTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96CB62D220D120900F13A36 /* MockDataTransport.swift */; };
+		C96CB630220D168800F13A36 /* TextDocumentIndentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96CB62F220D168800F13A36 /* TextDocumentIndentifier.swift */; };
 		C986779C21B45A3D00C1BE5A /* LanguageServerProcessHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986779B21B45A3D00C1BE5A /* LanguageServerProcessHost.swift */; };
 		C986779E21BB53E700C1BE5A /* SignatureHelp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986779D21BB53E700C1BE5A /* SignatureHelp.swift */; };
 		C992998921755D0900C5F8A5 /* SwiftLSPClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C992997F21755D0900C5F8A5 /* SwiftLSPClient.framework */; };
@@ -49,8 +53,12 @@
 
 /* Begin PBXFileReference section */
 		C90F9BB321773CB800EC3854 /* LanguageServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageServer.swift; sourceTree = "<group>"; };
+		C9361B5D220DD9F600254280 /* MockProtocolTransportMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProtocolTransportMessage.swift; sourceTree = "<group>"; };
 		C96CB61D220C8C2F00F13A36 /* SymbolKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolKind.swift; sourceTree = "<group>"; };
 		C96CB61F220C917B00F13A36 /* WorkspaceFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFolder.swift; sourceTree = "<group>"; };
+		C96CB629220D11D700F13A36 /* ProtocolTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTransportTests.swift; sourceTree = "<group>"; };
+		C96CB62D220D120900F13A36 /* MockDataTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataTransport.swift; sourceTree = "<group>"; };
+		C96CB62F220D168800F13A36 /* TextDocumentIndentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDocumentIndentifier.swift; sourceTree = "<group>"; };
 		C986779B21B45A3D00C1BE5A /* LanguageServerProcessHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerProcessHost.swift; sourceTree = "<group>"; };
 		C986779D21BB53E700C1BE5A /* SignatureHelp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureHelp.swift; sourceTree = "<group>"; };
 		C992997F21755D0900C5F8A5 /* SwiftLSPClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftLSPClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,6 +147,9 @@
 			children = (
 				C992998D21755D0900C5F8A5 /* MessageTransportTests.swift */,
 				C992998F21755D0900C5F8A5 /* Info.plist */,
+				C96CB629220D11D700F13A36 /* ProtocolTransportTests.swift */,
+				C96CB62D220D120900F13A36 /* MockDataTransport.swift */,
+				C9361B5D220DD9F600254280 /* MockProtocolTransportMessage.swift */,
 			);
 			path = SwiftLSPClientTests;
 			sourceTree = "<group>";
@@ -162,6 +173,7 @@
 				C99DBF3D21FE1DC2005AC5C5 /* ClientCapabilities.swift */,
 				C96CB61D220C8C2F00F13A36 /* SymbolKind.swift */,
 				C96CB61F220C917B00F13A36 /* WorkspaceFolder.swift */,
+				C96CB62F220D168800F13A36 /* TextDocumentIndentifier.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -317,6 +329,7 @@
 				C99299A521755D6900C5F8A5 /* MessageTransport.swift in Sources */,
 				C99DBF3C21FE1D69005AC5C5 /* ServerCapabilities.swift in Sources */,
 				C99299B621755D8A00C5F8A5 /* LanguageFeatures.swift in Sources */,
+				C96CB630220D168800F13A36 /* TextDocumentIndentifier.swift in Sources */,
 				C99DBF3E21FE1DC2005AC5C5 /* ClientCapabilities.swift in Sources */,
 				C99DBF3A21FE1A91005AC5C5 /* JSONValue.swift in Sources */,
 				C9D85CC721EF836C00B33336 /* Position.swift in Sources */,
@@ -328,7 +341,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C96CB62E220D120900F13A36 /* MockDataTransport.swift in Sources */,
 				C992998E21755D0900C5F8A5 /* MessageTransportTests.swift in Sources */,
+				C96CB62A220D11D700F13A36 /* ProtocolTransportTests.swift in Sources */,
+				C9361B5E220DD9F600254280 /* MockProtocolTransportMessage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftLSPClient.xcodeproj/xcshareddata/xcschemes/SwiftLSPClient.xcscheme
+++ b/SwiftLSPClient.xcodeproj/xcshareddata/xcschemes/SwiftLSPClient.xcscheme
@@ -26,10 +26,12 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C992998721755D0900C5F8A5"

--- a/SwiftLSPClient/JSONRPC/JSONRPC.swift
+++ b/SwiftLSPClient/JSONRPC/JSONRPC.swift
@@ -80,6 +80,27 @@ public struct JSONRPCResultResponse<T>: Codable where T: Codable {
     public let id: JSONId?
     public let result: T?
     public let error: ResponseError?
+
+    public init(id: JSONId, result: T) {
+        self.jsonrpc = "2.0"
+        self.id = id
+        self.result = result
+        self.error = nil
+    }
+
+    public init(id: Int, result: T) {
+        self.jsonrpc = "2.0"
+        self.id = JSONId.numericId(id)
+        self.result = result
+        self.error = nil
+    }
+
+    public init(id: JSONId, error: ResponseError) {
+        self.jsonrpc = "2.0"
+        self.id = id
+        self.result = nil
+        self.error = error
+    }
 }
 
 public struct JSONRPCNotification: Codable {

--- a/SwiftLSPClient/JSONRPCLanguageServer.swift
+++ b/SwiftLSPClient/JSONRPCLanguageServer.swift
@@ -24,7 +24,7 @@ public class JSONRPCLanguageServer {
 }
 
 extension JSONRPCLanguageServer: ProtocolTransportDelegate {
-    func transportReceived(_ transport: ProtocolTransport, undecodableData data: Data) {
+    public func transportReceived(_ transport: ProtocolTransport, undecodableData data: Data) {
         if let string = String(data: data, encoding: .utf8) {
             print("undecodable data received: \(string)")
         } else {
@@ -32,7 +32,7 @@ extension JSONRPCLanguageServer: ProtocolTransportDelegate {
         }
     }
 
-    func transportReceived(_ transport: ProtocolTransport, notificationMethod: String, data: Data) {
+    public func transportReceived(_ transport: ProtocolTransport, notificationMethod: String, data: Data) {
         guard let responder = notificationResponder else {
             return
         }

--- a/SwiftLSPClient/Types/Basic.swift
+++ b/SwiftLSPClient/Types/Basic.swift
@@ -68,14 +68,6 @@ public struct TextDocumentItem: Codable {
     }
 }
 
-public struct TextDocumentIdentifier: Codable {
-    public let uri: DocumentUri
-    
-    public init(uri: DocumentUri) {
-        self.uri = uri
-    }
-}
-
 public struct VersionedTextDocumentIdentifier: Codable {
     public let uri: DocumentUri
     public let version: Int?

--- a/SwiftLSPClient/Types/TextDocumentIndentifier.swift
+++ b/SwiftLSPClient/Types/TextDocumentIndentifier.swift
@@ -1,0 +1,29 @@
+//
+//  TextDocumentIndentifier.swift
+//  SwiftLSPClient
+//
+//  Created by Matt Massicotte on 2019-02-07.
+//  Copyright © 2019 Chime Systems. All rights reserved.
+//
+
+import Foundation
+
+public struct TextDocumentIdentifier {
+    public let uri: DocumentUri
+
+    public init(uri: DocumentUri) {
+        self.uri = uri
+    }
+}
+
+extension TextDocumentIdentifier: Codable {
+}
+
+extension TextDocumentIdentifier: Equatable {
+}
+
+extension TextDocumentIdentifier: CustomStringConvertible {
+    public var description: String {
+        return uri.description
+    }
+}

--- a/SwiftLSPClientTests/MessageTransportTests.swift
+++ b/SwiftLSPClientTests/MessageTransportTests.swift
@@ -9,35 +9,6 @@
 import XCTest
 @testable import SwiftLSPClient
 
-class MockDataTransport: DataTransport {
-    var writtenData: [Data]
-    var readHandler: ReadHandler?
-    
-    init() {
-        self.writtenData = []
-        self.readHandler = nil
-    }
-    
-    func write(_ data: Data) {
-        writtenData.append(data)
-    }
-    
-    func setReaderHandler(_ handler: @escaping ReadHandler) {
-        readHandler = handler
-    }
-
-    func close() {
-    }
-    
-    func mockRead(_ data: Data) {
-        self.readHandler?(data)
-    }
-    
-    func mockRead(_ string: String) {
-        mockRead(string.data(using: .utf8)!)
-    }
-}
-
 class MessageTransportTests: XCTestCase {
     func writeMessageAndReadResult(_ message: String) -> Data? {
         let results = writeMessagesAndReadResult([message])

--- a/SwiftLSPClientTests/MockDataTransport.swift
+++ b/SwiftLSPClientTests/MockDataTransport.swift
@@ -1,0 +1,39 @@
+//
+//  MockDataTransport.swift
+//  SwiftLSPClientTests
+//
+//  Created by Matt Massicotte on 2019-02-07.
+//  Copyright © 2019 Chime Systems. All rights reserved.
+//
+
+import Foundation
+import SwiftLSPClient
+
+class MockDataTransport: DataTransport {
+    var writtenData: [Data]
+    var readHandler: ReadHandler?
+
+    init() {
+        self.writtenData = []
+        self.readHandler = nil
+    }
+
+    func write(_ data: Data) {
+        writtenData.append(data)
+    }
+
+    func setReaderHandler(_ handler: @escaping ReadHandler) {
+        readHandler = handler
+    }
+
+    func close() {
+    }
+
+    func mockRead(_ data: Data) {
+        self.readHandler?(data)
+    }
+
+    func mockRead(_ string: String) {
+        mockRead(string.data(using: .utf8)!)
+    }
+}

--- a/SwiftLSPClientTests/MockProtocolTransportMessage.swift
+++ b/SwiftLSPClientTests/MockProtocolTransportMessage.swift
@@ -1,0 +1,21 @@
+//
+//  MockProtocolTransportMessage.swift
+//  SwiftLSPClientTests
+//
+//  Created by Matt Massicotte on 2019-02-08.
+//  Copyright © 2019 Chime Systems. All rights reserved.
+//
+
+import Foundation
+import SwiftLSPClient
+
+class MockProtocolTransportDelegate: ProtocolTransportDelegate {
+    var notificationHandler: ((String, Data) -> Void)?
+
+    func transportReceived(_ transport: ProtocolTransport, undecodableData data: Data) {
+    }
+
+    func transportReceived(_ transport: ProtocolTransport, notificationMethod: String, data: Data) {
+        notificationHandler?(notificationMethod, data)
+    }
+}

--- a/SwiftLSPClientTests/ProtocolTransportTests.swift
+++ b/SwiftLSPClientTests/ProtocolTransportTests.swift
@@ -1,0 +1,65 @@
+//
+//  ProtocolTransportTests.swift
+//  SwiftLSPClientTests
+//
+//  Created by Matt Massicotte on 2019-02-07.
+//  Copyright © 2019 Chime Systems. All rights reserved.
+//
+
+import XCTest
+import Result
+@testable import SwiftLSPClient
+
+class ProtocolTransportTests: XCTestCase {
+    typealias TestResult = Result<JSONRPCResultResponse<TextDocumentIdentifier>, ProtocolTransportError>
+
+    func testSendRequest() {
+        let dataTransport = MockDataTransport()
+        let messageTransport = MessageTransport(dataTransport: dataTransport)
+        let transport = ProtocolTransport(messageTransport: messageTransport)
+
+        let expectation = XCTestExpectation(description: "Response Message")
+
+        let request = TextDocumentIdentifier(uri: "hello")
+        transport.sendRequest(request, method: "mymethod") { (result: TestResult) in
+            XCTAssertNil(result.error)
+            XCTAssertEqual(result.value?.result, TextDocumentIdentifier(uri: "goodbye"))
+
+            expectation.fulfill()
+        }
+
+        dataTransport.mockRead("Content-Length: 51\r\n\r\n")
+        dataTransport.mockRead("""
+{"jsonrpc":"2.0","id":1,"result":{"uri":"goodbye"}}
+""")
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testNotification() {
+        let dataTransport = MockDataTransport()
+        let messageTransport = MessageTransport(dataTransport: dataTransport)
+        let transport = ProtocolTransport(messageTransport: messageTransport)
+        let transportDelegate = MockProtocolTransportDelegate()
+
+        transport.delegate = transportDelegate
+
+        let expectation = XCTestExpectation(description: "Notification Message")
+
+        transportDelegate.notificationHandler = { (method, data) in
+            XCTAssertEqual(method, "iamnotification")
+
+            let result = try? JSONDecoder().decode(JSONRPCNotificationParams<String>.self, from: data)
+
+            XCTAssertEqual(result?.params, "iamstring")
+            expectation.fulfill()
+        }
+
+        dataTransport.mockRead("Content-Length: 65\r\n\r\n")
+        dataTransport.mockRead("""
+{"jsonrpc":"2.0","method":"iamnotification","params":"iamstring"}
+""")
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
Before working on server->client requests, I though it would be useful to have some good tests in place for the ProtocolTransport class. Also, noticed that the DataTransport protocol fit nicely, to refactored to use that. I think this should make it possible to write some more straight-forward tests in the future.