### PR TITLE
Ensure textDocument/references matches LSP spec

### DIFF
--- a/SwiftLSPClient.xcodeproj/project.pbxproj
+++ b/SwiftLSPClient.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		C91160E5221106FF00B4F3AB /* WillSaveTextDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91160E4221106FF00B4F3AB /* WillSaveTextDocument.swift */; };
 		C91160EE2214F7A700B4F3AB /* TypeDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91160ED2214F7A700B4F3AB /* TypeDefinition.swift */; };
 		C91160F02214F86B00B4F3AB /* LocationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91160EF2214F86B00B4F3AB /* LocationLink.swift */; };
+		C91AE5B52365E99D00F3B364 /* Reference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91AE5B42365E99D00F3B364 /* Reference.swift */; };
 		C9233179231DF3CC000207E7 /* MessageActionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9233178231DF3CB000207E7 /* MessageActionItem.swift */; };
 		C923317B231DF43A000207E7 /* MessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923317A231DF43A000207E7 /* MessageType.swift */; };
 		C923317D231DF4AA000207E7 /* ShowMessageParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923317C231DF4AA000207E7 /* ShowMessageParams.swift */; };
@@ -75,6 +76,7 @@
 		C91160E4221106FF00B4F3AB /* WillSaveTextDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WillSaveTextDocument.swift; sourceTree = "<group>"; };
 		C91160ED2214F7A700B4F3AB /* TypeDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeDefinition.swift; sourceTree = "<group>"; };
 		C91160EF2214F86B00B4F3AB /* LocationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationLink.swift; sourceTree = "<group>"; };
+		C91AE5B42365E99D00F3B364 /* Reference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reference.swift; sourceTree = "<group>"; };
 		C9233178231DF3CB000207E7 /* MessageActionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionItem.swift; sourceTree = "<group>"; };
 		C923317A231DF43A000207E7 /* MessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageType.swift; sourceTree = "<group>"; };
 		C923317C231DF4AA000207E7 /* ShowMessageParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMessageParams.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 				C94941D723272BF200BCFC88 /* Declaration.swift */,
 				C94941D923272C0600BCFC88 /* Definition.swift */,
 				C94941DD23272C1B00BCFC88 /* Implementation.swift */,
+				C91AE5B42365E99D00F3B364 /* Reference.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -397,6 +400,7 @@
 				C923317D231DF4AA000207E7 /* ShowMessageParams.swift in Sources */,
 				C99299B321755D8A00C5F8A5 /* ProtocolMethod.swift in Sources */,
 				C99299A321755D6900C5F8A5 /* StdioDataTransport.swift in Sources */,
+				C91AE5B52365E99D00F3B364 /* Reference.swift in Sources */,
 				C96CB620220C917B00F13A36 /* WorkspaceFolder.swift in Sources */,
 				C96CB61E220C8C2F00F13A36 /* SymbolKind.swift in Sources */,
 				C99DBF4221FE3D42005AC5C5 /* LogMessageParams.swift in Sources */,

--- a/SwiftLSPClient/JSONRPCLanguageServer.swift
+++ b/SwiftLSPClient/JSONRPCLanguageServer.swift
@@ -258,10 +258,10 @@ extension JSONRPCLanguageServer: LanguageServer {
         }
     }
 
-    public func references(params: ReferencesParams, block: @escaping (LanguageServerResult<ReferencesResponse>) -> Void) {
+    public func references(params: ReferenceParams, block: @escaping (LanguageServerResult<ReferenceResponse?>) -> Void) {
         let method = ProtocolMethod.TextDocument.References
 
-        protocolTransport.sendRequest(params, method: method) { (result: ProtocolResponse<ReferencesResponse>) in
+        protocolTransport.sendRequest(params, method: method) { (result: ProtocolResponse<ReferenceResponse?>) in
             relayResult(result: result, block: block)
         }
     }

--- a/SwiftLSPClient/LanguageServer.swift
+++ b/SwiftLSPClient/LanguageServer.swift
@@ -70,7 +70,7 @@ public protocol LanguageServer: class {
     func formatting(params: DocumentFormattingParams, block: @escaping (LanguageServerResult<FormattingResult>) -> Void)
     func rangeFormatting(params: DocumentRangeFormattingParams, block: @escaping (LanguageServerResult<FormattingResult>) -> Void)
     func onTypeFormatting(params: DocumentOnTypeFormattingParams, block: @escaping (LanguageServerResult<FormattingResult>) -> Void)
-    func references(params: ReferencesParams, block: @escaping (LanguageServerResult<ReferencesResponse>) -> Void)
+    func references(params: ReferenceParams, block: @escaping (LanguageServerResult<ReferenceResponse?>) -> Void)
 }
 
 public protocol NotificationResponder: class {

--- a/SwiftLSPClient/Types/ClientCapabilities.swift
+++ b/SwiftLSPClient/Types/ClientCapabilities.swift
@@ -163,7 +163,7 @@ public struct TextDocumentClientCapabilities: Codable {
     public let completion: TextDocumentClientCapabilityCompletion?
     public let hover: TextDocumentClientCapabilityHover?
     public let signatureHelp: JSONValue?
-    public let references: JSONValue?
+    public let references: GenericDynamicRegistration?
     public let documentHighlight: JSONValue?
     public let documentSymbol: JSONValue?
     public let formatting: GenericDynamicRegistration?
@@ -181,12 +181,12 @@ public struct TextDocumentClientCapabilities: Codable {
     public let publishDiagnostics: TextDocumentClientCapabilityPublicDiagnostics?
     public let foldingRange: JSONValue?
 
-    public init(synchronization: TextDocumentClientCapabilitySynchronization?, completion: TextDocumentClientCapabilityCompletion?, hover: TextDocumentClientCapabilityHover?, formatting: GenericDynamicRegistration?, rangeFormatting: GenericDynamicRegistration?, onTypeFormatting: GenericDynamicRegistration?, declaration: TextDocumentClientCapabilitiesGenericGoTo? = nil, definition: TextDocumentClientCapabilitiesGenericGoTo? = nil, typeDefinition: TextDocumentClientCapabilitiesGenericGoTo? = nil, implemenation: TextDocumentClientCapabilitiesGenericGoTo? = nil, publishDiagnostics: TextDocumentClientCapabilityPublicDiagnostics?) {
+    public init(synchronization: TextDocumentClientCapabilitySynchronization?, completion: TextDocumentClientCapabilityCompletion?, hover: TextDocumentClientCapabilityHover?, references: GenericDynamicRegistration? = nil, formatting: GenericDynamicRegistration?, rangeFormatting: GenericDynamicRegistration?, onTypeFormatting: GenericDynamicRegistration?, declaration: TextDocumentClientCapabilitiesGenericGoTo? = nil, definition: TextDocumentClientCapabilitiesGenericGoTo? = nil, typeDefinition: TextDocumentClientCapabilitiesGenericGoTo? = nil, implemenation: TextDocumentClientCapabilitiesGenericGoTo? = nil, publishDiagnostics: TextDocumentClientCapabilityPublicDiagnostics?) {
         self.synchronization = synchronization
         self.completion = completion
         self.hover = hover
         self.signatureHelp = nil
-        self.references = nil
+        self.references = references
         self.documentHighlight = nil
         self.documentSymbol = nil
         self.formatting = formatting

--- a/SwiftLSPClient/Types/Features/Reference.swift
+++ b/SwiftLSPClient/Types/Features/Reference.swift
@@ -1,0 +1,37 @@
+//
+//  Reference.swift
+//  SwiftLSPClient
+//
+//  Created by Matt Massicotte on 2019-10-27.
+//  Copyright © 2019 Chime Systems. All rights reserved.
+//
+
+import Foundation
+
+public struct ReferenceContext: Codable {
+    public let includeDeclaration: Bool
+
+    public init(includeDeclaration: Bool) {
+        self.includeDeclaration = includeDeclaration
+    }
+}
+
+public struct ReferenceParams: Codable {
+    public let textDocument: TextDocumentIdentifier
+    public let position: Position
+    public let context: ReferenceContext
+
+    public init(textDocument: TextDocumentIdentifier, position: Position, context: ReferenceContext) {
+        self.textDocument = textDocument
+        self.position = position
+        self.context = context
+    }
+
+    public init(textDocument: TextDocumentIdentifier, position: Position, includeDeclaration: Bool) {
+        let ctx = ReferenceContext(includeDeclaration: includeDeclaration)
+
+        self.init(textDocument: textDocument, position: position, context: ctx)
+    }
+}
+
+public typealias ReferenceResponse = [Location]

--- a/SwiftLSPClient/Types/TextSynchronization.swift
+++ b/SwiftLSPClient/Types/TextSynchronization.swift
@@ -88,18 +88,3 @@ public struct DidCloseTextDocumentParams: Codable {
         self.init(textDocument: docId)
     }
 }
-
-public struct ReferencesParams: Codable {
-
-    public var textDocument: TextDocumentIdentifier
-    public var position: Position
-    public var includeDeclaration: Bool?
-
-    public init(textDocument: TextDocumentIdentifier, position: Position, includeDeclaration: Bool? = nil) {
-      self.textDocument = textDocument
-      self.position = position
-      self.includeDeclaration = includeDeclaration
-    }
-}
-
-public typealias ReferencesResponse = [Location]


### PR DESCRIPTION
There were a few minor issues with matching the spec. Forgiving servers don't seem to mind this, but its worth addressing before a release. Notable changes:

- `ReferencesParams` -> `ReferenceParams`
- addition of `ReferenceContext`, with non-optional `includeDeclaration` field
- `ReferencesResponse` -> `ReferenceResponse`, to be consistent with request
- `ReferenceResponse` can be optional
- Fill in `ClientCapabilities` for initialization

This addresses https://github.com/ChimeHQ/SwiftLSPClient/issues/26. Unfortunately, the naming changes are break clients that currently use what is on master.