### PR TITLE
Safety for protocol classes

### DIFF
--- a/SwiftLSPClient.xcodeproj/project.pbxproj
+++ b/SwiftLSPClient.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		C91160EE2214F7A700B4F3AB /* TypeDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91160ED2214F7A700B4F3AB /* TypeDefinition.swift */; };
 		C91160F02214F86B00B4F3AB /* LocationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91160EF2214F86B00B4F3AB /* LocationLink.swift */; };
 		C91AE5B52365E99D00F3B364 /* Reference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91AE5B42365E99D00F3B364 /* Reference.swift */; };
+		C91AE5BC2369D85000F3B364 /* JSONRPCLanguageServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91AE5BB2369D85000F3B364 /* JSONRPCLanguageServerTests.swift */; };
 		C9233179231DF3CC000207E7 /* MessageActionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9233178231DF3CB000207E7 /* MessageActionItem.swift */; };
 		C923317B231DF43A000207E7 /* MessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923317A231DF43A000207E7 /* MessageType.swift */; };
 		C923317D231DF4AA000207E7 /* ShowMessageParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923317C231DF4AA000207E7 /* ShowMessageParams.swift */; };
@@ -77,6 +78,7 @@
 		C91160ED2214F7A700B4F3AB /* TypeDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeDefinition.swift; sourceTree = "<group>"; };
 		C91160EF2214F86B00B4F3AB /* LocationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationLink.swift; sourceTree = "<group>"; };
 		C91AE5B42365E99D00F3B364 /* Reference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reference.swift; sourceTree = "<group>"; };
+		C91AE5BB2369D85000F3B364 /* JSONRPCLanguageServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCLanguageServerTests.swift; sourceTree = "<group>"; };
 		C9233178231DF3CB000207E7 /* MessageActionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionItem.swift; sourceTree = "<group>"; };
 		C923317A231DF43A000207E7 /* MessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageType.swift; sourceTree = "<group>"; };
 		C923317C231DF4AA000207E7 /* ShowMessageParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMessageParams.swift; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 				C96CB62D220D120900F13A36 /* MockDataTransport.swift */,
 				C9361B5D220DD9F600254280 /* MockProtocolTransportMessage.swift */,
 				C9361B63220E671400254280 /* TypeTests.swift */,
+				C91AE5BB2369D85000F3B364 /* JSONRPCLanguageServerTests.swift */,
 			);
 			path = SwiftLSPClientTests;
 			sourceTree = "<group>";
@@ -436,6 +439,7 @@
 			files = (
 				C9361B64220E671400254280 /* TypeTests.swift in Sources */,
 				C96CB62E220D120900F13A36 /* MockDataTransport.swift in Sources */,
+				C91AE5BC2369D85000F3B364 /* JSONRPCLanguageServerTests.swift in Sources */,
 				C992998E21755D0900C5F8A5 /* MessageTransportTests.swift in Sources */,
 				C96CB62A220D11D700F13A36 /* ProtocolTransportTests.swift in Sources */,
 				C9361B5E220DD9F600254280 /* MockProtocolTransportMessage.swift in Sources */,

--- a/SwiftLSPClient/JSONRPC/MessageTransport.swift
+++ b/SwiftLSPClient/JSONRPC/MessageTransport.swift
@@ -19,12 +19,16 @@ public class MessageTransport {
     public init(dataTransport: DataTransport) {
         self.dataTransport = dataTransport
         self.buffer = Data()
-        
-        self.dataTransport.setReaderHandler({ [unowned self] (data) in
+
+        setupReadHandler()
+    }
+
+    private func setupReadHandler() {
+        dataTransport.setReaderHandler({ [unowned self] (data) in
             guard data.count > 0 else {
                 return
             }
-            
+
             self.dataReceived(data)
         })
     }
@@ -135,10 +139,8 @@ public class MessageTransport {
         
         return (key, value, endOfHeader)
     }
-}
-
-extension MessageTransport: DataTransport {
-    public func write(_ data: Data) {
+    
+    public static func createMessage(with data: Data) -> Data {
         let length = data.count
 
         let header = "Content-Length: \(length)\r\n\r\n"
@@ -146,7 +148,13 @@ extension MessageTransport: DataTransport {
             fatalError()
         }
 
-        let messageData = headerData + data
+        return headerData + data
+    }
+}
+
+extension MessageTransport: DataTransport {
+    public func write(_ data: Data) {
+        let messageData = MessageTransport.createMessage(with: data)
 
         dataTransport.write(messageData)
     }

--- a/SwiftLSPClient/Types/Basic.swift
+++ b/SwiftLSPClient/Types/Basic.swift
@@ -139,6 +139,9 @@ public struct MarkupContent: Codable {
     public let value: String
 }
 
+extension MarkupContent: Equatable {
+}
+
 public struct TextEdit: Codable {
     public let range: LSPRange
     public let newText: String

--- a/SwiftLSPClient/Types/LanguageFeatures.swift
+++ b/SwiftLSPClient/Types/LanguageFeatures.swift
@@ -135,6 +135,9 @@ public struct LanguageStringPair: Codable {
     public let value: String
 }
 
+extension LanguageStringPair: Equatable {
+}
+
 public enum MarkedString: Codable {
     case string(String)
     case languageString(LanguageStringPair)
@@ -181,6 +184,9 @@ public enum MarkedString: Codable {
     }
 }
 
+extension MarkedString: Equatable {
+}
+
 public enum HoverContents: Codable {
     case markedString(MarkedString)
     case markedStringArray([MarkedString])
@@ -213,7 +219,13 @@ public enum HoverContents: Codable {
     }
 }
 
+extension HoverContents: Equatable {
+}
+
 public struct Hover: Codable {
     public let contents: HoverContents
     public let range: LSPRange?
+}
+
+extension Hover: Equatable {
 }

--- a/SwiftLSPClientTests/JSONRPCLanguageServerTests.swift
+++ b/SwiftLSPClientTests/JSONRPCLanguageServerTests.swift
@@ -1,0 +1,54 @@
+//
+//  JSONRPCLanguageServerTests.swift
+//  SwiftLSPClientTests
+//
+//  Created by Matt Massicotte on 2019-10-30.
+//  Copyright © 2019 Chime Systems. All rights reserved.
+//
+
+import XCTest
+import SwiftLSPClient
+
+class JSONRPCLanguageServerTests: XCTestCase {
+    func testHoverRequest() throws {
+        let dataTransport = MockDataTransport()
+
+        let server = JSONRPCLanguageServer(dataTransport: dataTransport)
+
+        let textDocId = TextDocumentIdentifier(uri: "file://somefile.txt")
+        let position = Position(line: 5, character: 5)
+        let params = TextDocumentPositionParams(textDocument: textDocId, position: position)
+
+        var result: LanguageServerResult<Hover>? = nil
+
+        let exp = XCTestExpectation(description: "Server Result Expectation")
+
+        server.hover(params: params) { (serverResult) in
+            result = serverResult
+
+            exp.fulfill()
+        }
+
+        // now write the response
+        let serverResponse = "Content-Length: 130\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"contents\":\"foo\",\"range\":{\"start\":{\"line\":10,\"character\":10},\"end\":{\"line\":20,\"character\":20}}}}"
+        dataTransport.mockRead(serverResponse)
+
+        wait(for: [exp], timeout: 1.0)
+
+        // verify the request
+        let clientRequest = "Content-Length: 149\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"textDocument\\/hover\",\"params\":{\"textDocument\":{\"uri\":\"file:\\/\\/somefile.txt\"},\"position\":{\"line\":5,\"character\":5}}}"
+
+        let writtenStrings = dataTransport.writtenData.compactMap({ String(data: $0, encoding: .utf8) })
+
+        XCTAssertEqual(writtenStrings, [clientRequest])
+
+        // and verify the response
+        guard let hover = try result?.get() else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(hover.contents, HoverContents.markedString(MarkedString.string("foo")))
+        XCTAssertEqual(hover.range, LSPRange(startPair: (10, 10), endPair: (20, 20)))
+    }
+}

--- a/SwiftLSPClientTests/TypeTests.swift
+++ b/SwiftLSPClientTests/TypeTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import SwiftLSPClient
 
 class TypeTests: XCTestCase {
-    func testSomething() {
+    func testSymbolInformation() {
         let json = """
 {"id":2,"result":[{"name":"something","kind":12,"location":{"uri":"file:///hello.go","range":{"start":{"line":19,"character":5},"end":{"line":19,"character":13}}}}],"jsonrpc":"2.0"}
 """


### PR DESCRIPTION
It turns out that I was assuming that NSFileManager still did its synchronization via a runloop exclusively. This was incredibly incorrect, and results in terrible thread safety issues for many classes. I've attempted to use queues to serialize access to the necessary resources.

Would be really great to built a little stress-test for this. Have to think a little more on how exactly to do that.