### PR TITLE
Test data without strings

### DIFF
--- a/SwiftLSPClient.xcodeproj/project.pbxproj
+++ b/SwiftLSPClient.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C91160F02214F86B00B4F3AB /* LocationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91160EF2214F86B00B4F3AB /* LocationLink.swift */; };
 		C91AE5B52365E99D00F3B364 /* Reference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91AE5B42365E99D00F3B364 /* Reference.swift */; };
 		C91AE5BC2369D85000F3B364 /* JSONRPCLanguageServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91AE5BB2369D85000F3B364 /* JSONRPCLanguageServerTests.swift */; };
+		C91AE5C1236A679D00F3B364 /* JSONRPC+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91AE5C0236A679D00F3B364 /* JSONRPC+Helpers.swift */; };
 		C9233179231DF3CC000207E7 /* MessageActionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9233178231DF3CB000207E7 /* MessageActionItem.swift */; };
 		C923317B231DF43A000207E7 /* MessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923317A231DF43A000207E7 /* MessageType.swift */; };
 		C923317D231DF4AA000207E7 /* ShowMessageParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923317C231DF4AA000207E7 /* ShowMessageParams.swift */; };
@@ -79,6 +80,7 @@
 		C91160EF2214F86B00B4F3AB /* LocationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationLink.swift; sourceTree = "<group>"; };
 		C91AE5B42365E99D00F3B364 /* Reference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reference.swift; sourceTree = "<group>"; };
 		C91AE5BB2369D85000F3B364 /* JSONRPCLanguageServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCLanguageServerTests.swift; sourceTree = "<group>"; };
+		C91AE5C0236A679D00F3B364 /* JSONRPC+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONRPC+Helpers.swift"; sourceTree = "<group>"; };
 		C9233178231DF3CB000207E7 /* MessageActionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionItem.swift; sourceTree = "<group>"; };
 		C923317A231DF43A000207E7 /* MessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageType.swift; sourceTree = "<group>"; };
 		C923317C231DF4AA000207E7 /* ShowMessageParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMessageParams.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				C9361B5D220DD9F600254280 /* MockProtocolTransportMessage.swift */,
 				C9361B63220E671400254280 /* TypeTests.swift */,
 				C91AE5BB2369D85000F3B364 /* JSONRPCLanguageServerTests.swift */,
+				C91AE5C0236A679D00F3B364 /* JSONRPC+Helpers.swift */,
 			);
 			path = SwiftLSPClientTests;
 			sourceTree = "<group>";
@@ -443,6 +446,7 @@
 				C992998E21755D0900C5F8A5 /* MessageTransportTests.swift in Sources */,
 				C96CB62A220D11D700F13A36 /* ProtocolTransportTests.swift in Sources */,
 				C9361B5E220DD9F600254280 /* MockProtocolTransportMessage.swift in Sources */,
+				C91AE5C1236A679D00F3B364 /* JSONRPC+Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftLSPClient/JSONRPC/JSONRPC.swift
+++ b/SwiftLSPClient/JSONRPC/JSONRPC.swift
@@ -57,6 +57,18 @@ public struct JSONRPCRequest<T>: Codable where T: Codable {
     public let id: JSONId
     public let method: String
     public let params: T?
+
+    public init(id: JSONId, method: String, params: T? = nil) {
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+
+    public init(id: Int, method: String, params: T? = nil) {
+        let numericId = JSONId.numericId(id)
+
+        self.init(id: numericId, method: method, params: params)
+    }
 }
 
 public struct ResponseError: Codable {

--- a/SwiftLSPClient/JSONRPC/MessageTransport.swift
+++ b/SwiftLSPClient/JSONRPC/MessageTransport.swift
@@ -140,7 +140,7 @@ public class MessageTransport {
         return (key, value, endOfHeader)
     }
     
-    public static func createMessage(with data: Data) -> Data {
+    public static func prependHeaders(to data: Data) -> Data {
         let length = data.count
 
         let header = "Content-Length: \(length)\r\n\r\n"
@@ -154,7 +154,7 @@ public class MessageTransport {
 
 extension MessageTransport: DataTransport {
     public func write(_ data: Data) {
-        let messageData = MessageTransport.createMessage(with: data)
+        let messageData = MessageTransport.prependHeaders(to: data)
 
         dataTransport.write(messageData)
     }

--- a/SwiftLSPClient/JSONRPC/ProtocolTransport.swift
+++ b/SwiftLSPClient/JSONRPC/ProtocolTransport.swift
@@ -157,4 +157,3 @@ public class ProtocolTransport {
         self.delegate?.transportReceived(self, notificationMethod: method, data: data)
     }
 }
-

--- a/SwiftLSPClient/Types/Basic.swift
+++ b/SwiftLSPClient/Types/Basic.swift
@@ -124,6 +124,12 @@ public struct TextDocumentPositionParams: Codable {
         self.textDocument = textDocument
         self.position = position
     }
+
+    public init(uri: DocumentUri, position: Position) {
+        let textDocId = TextDocumentIdentifier(uri: uri)
+
+        self.init(textDocument: textDocId, position: position)
+    }
 }
 
 public struct DocumentFilter: Codable {

--- a/SwiftLSPClient/Types/LanguageFeatures.swift
+++ b/SwiftLSPClient/Types/LanguageFeatures.swift
@@ -225,6 +225,11 @@ extension HoverContents: Equatable {
 public struct Hover: Codable {
     public let contents: HoverContents
     public let range: LSPRange?
+
+    public init(contents: HoverContents, range: LSPRange? = nil) {
+        self.contents = contents
+        self.range = range
+    }
 }
 
 extension Hover: Equatable {

--- a/SwiftLSPClientTests/JSONRPC+Helpers.swift
+++ b/SwiftLSPClientTests/JSONRPC+Helpers.swift
@@ -1,0 +1,30 @@
+//
+//  JSONRPC+Helpers.swift
+//  SwiftLSPClientTests
+//
+//  Created by Matt Massicotte on 2019-10-30.
+//  Copyright © 2019 Chime Systems. All rights reserved.
+//
+
+import Foundation
+import SwiftLSPClient
+
+protocol ProtocolEncodable: Encodable {
+}
+
+extension ProtocolEncodable {
+    func encodeToProtocolData() throws -> Data {
+        let payloadData = try JSONEncoder().encode(self)
+
+        return MessageTransport.prependHeaders(to: payloadData)
+    }
+}
+
+extension JSONRPCResultResponse: ProtocolEncodable {
+}
+
+extension JSONRPCNotificationParams: ProtocolEncodable {
+}
+
+extension JSONRPCRequest: ProtocolEncodable {
+}


### PR DESCRIPTION
It wasn't possible to easily encode the LSP types to protocol messages for testing. So, I was just using strings. This was really annoying and error-prone. Finally took the time to make this possible, and it is way better.