### PR TITLE
Add back headers for Obj-C

### DIFF
--- a/SwiftLSPClient/Types/Basic.swift
+++ b/SwiftLSPClient/Types/Basic.swift
@@ -67,6 +67,7 @@ public enum LanguageIdentifier: String, Codable, CaseIterable {
         "cpp": .cpp,
         "m": .objc,
         "mm": .objcpp,
+        "h": .objcpp,
     ]
 
     public enum LanguageServerParameterError: Error {


### PR DESCRIPTION
Hi @mattmassicotte, I've been testing Objective-C and we really need to the header type back in. I was confused before by the various debug messages on the console.