### PR TITLE
".hpp" file extension. 'data' field in received errors optional.

### DIFF
--- a/SwiftLSPClient/JSONRPC/JSONRPC.swift
+++ b/SwiftLSPClient/JSONRPC/JSONRPC.swift
@@ -74,7 +74,7 @@ public struct JSONRPCRequest<T>: Codable where T: Codable {
 public struct ResponseError: Codable {
     public let code: Int
     public let message: String
-    public let data: JSONValue
+    public let data: JSONValue?
 
     public var languageServerError: LanguageServerError {
         return LanguageServerError.serverError(code: code, message: message, data: nil)

--- a/SwiftLSPClient/Types/Basic.swift
+++ b/SwiftLSPClient/Types/Basic.swift
@@ -69,6 +69,7 @@ public enum LanguageIdentifier: String, Codable, CaseIterable {
         "m": .objc,
         "mm": .objcpp,
         "h": .objcpp,
+        "hpp": .objcpp,
     ]
 
     public enum LanguageServerParameterError: Error {


### PR DESCRIPTION
Me again, You're right, adding '.hpp' this time. Not entirely sure about .h and .hpp being objcpp but using Swift most users will be on Apple systems I figure.